### PR TITLE
Dutch names

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -142,6 +142,12 @@ describe('Lexical Order', function() {
         assert.equal(name.last, 'Miller');
     });
 
+    it('Vincent van Gogh', function() {
+        var name = whosit.parse('Vincent van Gogh');
+        assert.equal(name.first, 'Vincent');
+        assert.equal(name.last, 'van Gogh');
+    });
+
     it('Vincent Willem van Gogh', function() {
         var name = whosit.parse('Vincent Willem van Gogh');
         assert.equal(name.first, 'Vincent');

--- a/test/test.js
+++ b/test/test.js
@@ -141,4 +141,11 @@ describe('Lexical Order', function() {
         assert.equal(name.middle, 'Michael');
         assert.equal(name.last, 'Miller');
     });
+
+    it('Vincent Willem van Gogh', function() {
+        var name = whosit.parse('Vincent Willem van Gogh');
+        assert.equal(name.first, 'Vincent');
+        assert.equal(name.middle, 'Willem');
+        assert.equal(name.last, 'van Gogh');
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -148,4 +148,11 @@ describe('Lexical Order', function() {
         assert.equal(name.middle, 'Willem');
         assert.equal(name.last, 'van Gogh');
     });
+
+    it('Vincent Willem Dennis van Gogh', function() {
+        var name = whosit.parse('Vincent Willem Dennis van Gogh');
+        assert.equal(name.first, 'Vincent');
+        assert.equal(name.middle, 'Willem Dennis');
+        assert.equal(name.last, 'van Gogh');
+    });
 });


### PR DESCRIPTION
I'm not actually using whosit but was just playing around, and found some problems with Dutch names.

This PR is a bug report demonstrated via one passing and two failing tests.

It correctly parses [Vincent] [Willem] [van Gogh].

But it misparses [Vincent] [van Gogh] as [Vincent] [van] [Gogh].

And it misparses [Vincent] [Willem Dennis] [van Gogh] as [Vincent] [Willem] [Dennis van Gogh].

Perhaps some heuristics for "van" and "von"? There may be similar problems with "de" and "de la" and so on.
