### PR TITLE
Switch tests to node:test

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,6 @@ module.exports = [
             },
             globals: {
                 ...globals.es2020,
-                ...globals.mocha,
                 ...globals.node,
                 //added for 'fetch()' access
                 ...globals.serviceworker

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
         "@eslint/js": "*",
         "globals": "*",
         "coveralls": "*",
-        "mocha": "*",
         "nyc": "*"
     },
     "keywords": [
@@ -15,8 +14,8 @@
     "name": "whosit",
     "repository": "git://github.com/mediocre/whosit.git",
     "scripts": {
-        "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
-        "test": "mocha --reporter spec"
+        "coveralls": "nyc node --test && nyc report --reporter=text-lcov | coveralls",
+        "test": "node --test"
     },
     "version": "1.2.0"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
-var assert = require('assert');
-var whosit = require('../lib');
+const assert = require('assert');
+const { describe, it } = require('node:test');
+const whosit = require('../lib');
 
 describe('Western Order', function() {
     it('Shawn', function() {


### PR DESCRIPTION
## Summary
- migrate mocha tests to the built-in `node:test` runner
- drop mocha from dev dependencies
- run tests via `node --test`
- remove mocha globals from ESLint config

## Testing
- `node --test`
- `npm test`