### PR TITLE
Fix workflow step name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install ESLint
       run: npm install -g eslint
 
-    - name: Install ESLine dependencies
+    - name: Install ESLint dependencies
       run: npm install globals @eslint/js
 
     - name: Run ESLint


### PR DESCRIPTION
## Summary
- fix ESLint step name in CI workflow

## Testing
- `npm test` *(fails: mocha not found)*